### PR TITLE
Update CircleCI to use mysql 5.7 non-circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
       - image: circleci/ruby:2.6
         environment:
           BUNDLE_VERSION: "~> 1.17"
-      - image: circleci/mysql:5.7
+      - image: mysql:5.7
         command: ["--sql-mode="]
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,10 @@ executors:
       - image: circleci/ruby:2.6
         environment:
           BUNDLE_VERSION: "~> 1.17"
-      - image: circleci/mysql:5.6
+      - image: circleci/mysql:5.7
+        command: ["--sql-mode="]
+        environment:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
 
 # yaml anchor filters
 master_only: &master_only


### PR DESCRIPTION
Story link: https://doximity.atlassian.net/browse/INFRASERVICES-180078586

Overview
--------

All DBs are running mysql 5.7, so CI should check against that mysql version

Technical Details
-----------------

The CircleCI MySQL image is deprecated so we're using the mysql image. The mysql image needs to allow empty password. We also set the sql_mode to blank server side since that's how it is in production. Rails enables strict mode through ActiveRecord in the mysql session
